### PR TITLE
chore: switch dependabot to weekly schedule with dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,16 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "05:00"
-
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "05:00"
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Switch all dependabot update schedules from daily to weekly and add an `all-dependencies` group for each ecosystem, so updates are batched into a single PR per toolchain rather than one PR per package.